### PR TITLE
Using rsync to copy hidden files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7.1-alpine AS builder
 LABEL maintainer="Mike Rogers <me@mikerogers.io>"
 
 RUN apk add --no-cache \
-    build-base bash \
+    build-base rsync \
     git
 
 FROM builder as rails-installer

--- a/docker/interactive-install.rb
+++ b/docker/interactive-install.rb
@@ -17,11 +17,7 @@ system("rm /usr/src/app/#{@app_path}/config/master.key")
 system("rm /usr/src/app/#{@app_path}/config/database.yml") 
 
 # Copy the docker files
-system("cp -ra /usr/src/App-Template/* /usr/src/app/#{@app_path}/")
-
-# Copy the hidden files
-system("cp -ra /usr/src/App-Template/.env.sample /usr/src/app/#{@app_path}/.env.sample")
-system("cp -ra /usr/src/App-Template/.dockerignore /usr/src/app/#{@app_path}/.dockerignore")
+system("rsync -a /usr/src/App-Template/ /usr/src/app/#{@app_path}/")
 
 # Copy sample files
 system("cp -ra /usr/src/App-Template/.env.sample /usr/src/app/#{@app_path}/.env")


### PR DESCRIPTION
Not all the hidden files we're copying reliably, so using rsync over `cp`.