### PR TITLE
Increase Postgres version to 12.3

### DIFF
--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -33,7 +33,7 @@ x-app: &app
 
 services:
   postgres:
-    image: postgres:11.7-alpine
+    image: postgres:12.3-alpine
     mem_limit: 64m
     volumes:
       - postgresql:/var/lib/postgresql/data:delegated


### PR DESCRIPTION
12.3 is the latest version available on Heroku, so defaulting to that.