### PR TITLE
bug: Removing yarn cache clean --all from Dockerfile

### DIFF
--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -116,8 +116,7 @@ COPY package.json /usr/src/app
 COPY yarn.lock /usr/src/app
 
 # Install Yarn Libraries
-RUN yarn install --frozen-lockfile --check-files \
-      && yarn cache clean --all
+RUN yarn install --frozen-lockfile --check-files
 
 # Chown files so non are root.
 COPY --chown=appuser:appgroup . /usr/src/app


### PR DESCRIPTION
Closes: https://github.com/Ruby-Starter-Kits/Docker-Rails-Generator/issues/91

Cleaning the yarn cache throws a permission error (I think because I chmod that folder to be owned by another user). I think I'm going to remove that LOC in the short term & work on a better solution later on.